### PR TITLE
Update to use iCalendar 3.9. Increases iCal compatability

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,7 +23,7 @@ def convert_from_url(url):
         abort(404)
     ics = uh.read()
     uh.close()
-    cal = Calendar.from_string(ics)
+    cal = Calendar.from_ical(ics)
     data = {}
     data[cal.name] = dict(cal.items())
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ Jinja2==2.6
 Werkzeug==0.8.3
 distribute==0.7.3
 gunicorn==18.0
-icalendar==2.2
+icalendar==3.9.1
 pytz==2012c
 wsgiref==0.1.2


### PR DESCRIPTION
This pull request allows parsing iCal files from both Google Calendar and Apple iCloud.