### PR TITLE
Appended to_ical() on item[1] to convert objects to string value.

### DIFF
--- a/app.py
+++ b/app.py
@@ -33,7 +33,7 @@ def convert_from_url(url):
 
         comp_obj = {}
         for item in component.items():
-            comp_obj[item[0]] = unicode(item[1])
+            comp_obj[item[0]] = unicode(item[1].to_ical())
 
         data[cal.name][component.name].append(comp_obj)
 


### PR DESCRIPTION
This commit fixes the issue https://github.com/philippbosch/ical2json/issues/1 reported by rbpasker commented on Feb 1, 2013. The issue was caused by the update of the icalendar package from version 2.2 to 3.9.1 in pull request https://github.com/philippbosch/ical2json/pull/3/files.